### PR TITLE
Fix crash that can lead to stack overflow as script attempts to print stack trace of itself!

### DIFF
--- a/src/StackTracePlus.lua
+++ b/src/StackTracePlus.lua
@@ -171,7 +171,7 @@ local function DumpLocals(level, message)
 			else
 				local txt = "{"
 				for k,v in pairs(value) do
-					txt = txt..k..":"..tostring(v)
+					txt = txt..tostring(k)..":"..tostring(v)
 					if #txt > 70 then
 						txt = txt.." (more...)"
 						break


### PR DESCRIPTION
Fixes:
ERROR: scripts/stack_trace_plus.lua:174: attempt to concatenate local
'k' (a table value)
