### PR TITLE
Remove trailing whitespace (to suppress luacheck warnings)

### DIFF
--- a/src/StackTracePlus.lua
+++ b/src/StackTracePlus.lua
@@ -76,7 +76,7 @@ for _, name in ipairs{
 	"tostring",
 	"type",
 	"xpcall",
-	
+
 	-- Lua 5.1
 	"gcinfo",
 	"getfenv",
@@ -102,7 +102,7 @@ local function safe_tostring (value)
 end
 
 -- Private:
--- Parses a line, looking for possible function definitions (in a very naïve way) 
+-- Parses a line, looking for possible function definitions (in a very naïve way)
 -- Returns '(anonymous)' if no function name was found in the line
 local function ParseLine(line)
 	assert(type(line) == "string")
@@ -228,7 +228,7 @@ function Dumper:DumpLocals (level)
 	if self.dumping_same_thread then
 		level = level + 1
 	end
-	
+
 	local name, value = self.getlocal(level, i)
 	if not name then
 		return
@@ -309,7 +309,7 @@ function _M.stacktrace(thread, message, level)
 	local dumper = Dumper.new(thread)
 
 	local original_error
-	
+
 	if type(message) == "table" then
 		dumper:add("an error object {\r\n")
 		local first = true
@@ -330,14 +330,14 @@ function _M.stacktrace(thread, message, level)
 		dumper:add(message)
 		original_error = message
 	end
-	
+
 	dumper:add("\r\n")
 	dumper:add[[
 Stack Traceback
 ===============
 ]]
 	--print(error_message)
-	
+
 	local level_to_show = level
 	if dumper.dumping_same_thread then level = level + 1 end
 
@@ -385,12 +385,12 @@ Stack Traceback
 		else
 			dumper:add_f("(%d) unknown frame %s\r\n", level_to_show, info.what)
 		end
-		
+
 		level = level + 1
 		level_to_show = level_to_show + 1
 		info = dumper.getinfo(level, "nSlf")
 	end
-	
+
 	return dumper:concat_lines(), original_error
 end
 


### PR DESCRIPTION
When checking StackTracePlus with the latest version of Luacheck (0.26.1), trailing whitespace is flagged on several lines.